### PR TITLE
ci: harden GitHub Actions workflows (zizmor audit)

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -6,17 +6,24 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   linux-build:
     name: Linux - amd64
     runs-on: ubuntu-latest # TODO try using grafana runners
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - name: Build in Docker
         run: make wheel/linux/amd64
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: "linux.whl"
           path: pyroscope_ffi/python/dist/*
@@ -29,6 +36,8 @@ jobs:
     needs: [ 'linux-build' ]
     name: Linux Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       PYROSCOPE_RUN_ID: ${{ github.run_id }}
       PYROSCOPE_ARCH: x86-64-linux
@@ -36,31 +45,37 @@ jobs:
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: x64
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2
         with:
           name: "linux.whl"
           path: "${{github.workspace}}/python"
 
       - run: "cd ${{ github.workspace }}/python && ls -l"
       - run: "cd ${{ github.workspace }}/python && pip install *.whl"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - run: docker run -d -p4040:4040 grafana/pyroscope
       - run: python pyroscope_ffi/python/scripts/tests/test.py
 
   linux-arm-build:
     name: Linux - arm64
     runs-on: [self-hosted, Linux, ARM64]
+    permissions:
+      contents: read
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v3
+      - uses: AutoModality/action-clean@492b2d2e2e77247bfd0b17eaa89a371b2f3430ee # v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - name: Build in Docker
         run: make wheel/linux/arm64
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: "linux-arm.whl"
           path: pyroscope_ffi/python/dist/*
@@ -68,10 +83,14 @@ jobs:
   sdist-build:
     name: sdist
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: 3.9
       - name: Upgrade pip
@@ -81,7 +100,7 @@ jobs:
         run: python setup.py sdist
         working-directory: pyroscope_ffi/python
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: "sdist.whl"
           path: pyroscope_ffi/python/dist/*
@@ -102,22 +121,24 @@ jobs:
 
     name: macOS - ${{ matrix.py-platform }}
     runs-on: macos-${{ matrix.macos-version }}
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.76.0
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
+          targets: ${{ matrix.target }}
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: 3.11
 
       - run: make wheel/mac/${{ matrix.mk-arch }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build in Docker
         run: make wheel/linux/amd64
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "linux.whl"
           path: pyroscope_ffi/python/dist/*
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: x64
-      - uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: "linux.whl"
           path: "${{github.workspace}}/python"
@@ -75,7 +75,7 @@ jobs:
       - name: Build in Docker
         run: make wheel/linux/arm64
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "linux-arm.whl"
           path: pyroscope_ffi/python/dist/*
@@ -100,7 +100,7 @@ jobs:
         run: python setup.py sdist
         working-directory: pyroscope_ffi/python
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "sdist.whl"
           path: pyroscope_ffi/python/dist/*
@@ -138,7 +138,7 @@ jobs:
           python-version: 3.11
 
       - run: make wheel/mac/${{ matrix.mk-arch }}
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: macos-${{ matrix.mk-arch }}-py
           path: pyroscope_ffi/python/dist/*

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           persist-credentials: false
       - run: make gem/linux/amd64
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "linux.gem"
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -57,9 +57,9 @@ jobs:
           toolchain: 1.76.0
           targets: ${{ matrix.target }}
       - run: make gem/mac/${{ matrix.mk-arch }}
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: macos-${{ matrix.mk-arch }}-gem
           path: pyroscope_ffi/ruby/pkg/*.gem
 
   linux-test:
@@ -78,7 +78,7 @@ jobs:
       - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: ${{ matrix.RUBY_VERSION }}
-      - uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: "linux.gem"
           path: "${{github.workspace}}/ruby"

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -6,16 +6,23 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   linux-build:
     name: Build linux gem amd64
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v3
+      - uses: AutoModality/action-clean@492b2d2e2e77247bfd0b17eaa89a371b2f3430ee # v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - run: make gem/linux/amd64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: "linux.gem"
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -32,23 +39,25 @@ jobs:
             mk-arch: arm64
     name: macOS - ${{ matrix.target }}
     runs-on: macos-${{ matrix.macos-version }}
+    permissions:
+      contents: read
 
     env:
       RUST_TARGET: ${{ matrix.target }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '3.1'
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.76.0
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
+          targets: ${{ matrix.target }}
       - run: make gem/mac/${{ matrix.mk-arch }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -63,17 +72,21 @@ jobs:
     needs: ['linux-build']
     name: Linux Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: ${{ matrix.RUBY_VERSION }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2
         with:
           name: "linux.gem"
           path: "${{github.workspace}}/ruby"
       - run: "cd ${{ github.workspace }}/ruby && ls -l"
       - run: "cd ${{ github.workspace }}/ruby && gem install *.gem"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - name: Run Ruby Script
         run: pyroscope_ffi/ruby/scripts/tests/test.rb
         env:
@@ -83,4 +96,3 @@ jobs:
           PYROSCOPE_DETECT_SUBPROCESSES: ${{ matrix.PYROSCOPE_DETECT_SUBPROCESSES }}
           PYROSCOPE_ONCPU: ${{ matrix.PYROSCOPE_ONCPU }}
           RUBY_VERSION: ${{ matrix.RUBY_VERSION }}
-

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,43 @@
+name: Create Release
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      release_name:
+        required: true
+        type: string
+      draft:
+        required: false
+        type: boolean
+        default: true
+      prerelease:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      token:
+        required: true
+    outputs:
+      upload_url:
+        description: "Upload URL for release assets"
+        value: ${{ jobs.create-release.outputs.upload_url }}
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+    steps:
+      - id: release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          token: ${{ secrets.token }}
+          tag: ${{ inputs.tag }}
+          name: ${{ inputs.release_name }}
+          draft: ${{ inputs.draft }}
+          prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,17 +5,23 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish-pyroscope:
     name: pyroscope-lib
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: "startsWith(github.event.release.tag_name, 'lib-')"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
-          override: true
       - name: publish pyroscope crate
         continue-on-error: true
         run: |
@@ -26,13 +32,13 @@ jobs:
 #    runs-on: ubuntu-latest
 #    if: "startsWith(github.event.release.tag_name, 'cli-')"
 #    steps:
-#      - uses: actions/checkout@v3
+#      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 #        with:
 #          submodules: recursive
-#      - uses: actions-rs/toolchain@v1
+#          persist-credentials: false
+#      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
 #        with:
 #          toolchain: stable
-#          override: true
 #      - name: install libunwind (for pprof)
 #        run: sudo apt install libunwind8-dev
 #      - name: publish pyroscope crate
@@ -43,13 +49,16 @@ jobs:
   publish-pprofrs:
     name: "Backend: pprofrs"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: "startsWith(github.event.release.tag_name, 'pprofrs-')"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
-          override: true
       - name: publish pprofrs crate
         continue-on-error: true
         run: |
@@ -58,59 +67,70 @@ jobs:
   publish-rbspy:
     name: "Backend: rbspy"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: "startsWith(github.event.release.tag_name, 'rbspy-')"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
-          override: true
       - name: publish rbspy crate
         continue-on-error: true
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish --manifest-path pyroscope_backends/pyroscope_rbspy/Cargo.toml
   publish-pyspy:
-    name: "Backend: pyspy" 
+    name: "Backend: pyspy"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: "startsWith(github.event.release.tag_name, 'pyspy-')"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
-          override: true
       - name: publish pyspy crate
         continue-on-error: true
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish --manifest-path pyroscope_backends/pyroscope_pyspy/Cargo.toml
   publish-python:
-    name: "Python" 
+    name: "Python"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     if: "startsWith(github.event.release.tag_name, 'python-')"
     steps:
-      - uses: robinraju/release-downloader@v1.4
-        with: 
+      - uses: robinraju/release-downloader@ed86e52bc497d1185844fc28454c5999aaed2fa5 # v1.4
+        with:
           tag: ${{ github.event.release.tag_name }}
           fileName: "*"
-          tarBall: false 
-          zipBall: false 
+          tarBall: false
+          zipBall: false
           out-file-path: "dist"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
   list-ruby-gems:
     name: "List ruby gems"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: "startsWith(github.event.release.tag_name, 'ruby-')"
     outputs:
       files_json: ${{ steps.list-files.outputs.files_json }}
     steps:
-      - uses: robinraju/release-downloader@v1.4
+      - uses: robinraju/release-downloader@ed86e52bc497d1185844fc28454c5999aaed2fa5 # v1.4
         with:
           tag: ${{ github.event.release.tag_name }}
           fileName: "*"
@@ -128,6 +148,8 @@ jobs:
     needs: list-ruby-gems
     name: "gem push"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: "startsWith(github.event.release.tag_name, 'ruby-')"
     env:
       GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
@@ -135,17 +157,20 @@ jobs:
       matrix:
         file: ${{ fromJson(needs.list-ruby-gems.outputs.files_json) }}
     steps:
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '3.1'
-      - uses: robinraju/release-downloader@v1.4
-        with: 
+      - uses: robinraju/release-downloader@ed86e52bc497d1185844fc28454c5999aaed2fa5 # v1.4
+        with:
           tag: ${{ github.event.release.tag_name }}
           fileName: "*"
-          tarBall: false 
-          zipBall: false 
+          tarBall: false
+          zipBall: false
           out-file-path: "dist"
           token: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
+      - name: Push gem
+        env:
+          GEM_FILE: ${{ matrix.file }}
+        run: |
           cd dist
-          gem push ${{ matrix.file }}
+          gem push "$GEM_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,19 @@ permissions:
 jobs:
   lib-release:
     name: pyroscope-main
-    runs-on: ubuntu-latest
     permissions:
       contents: write
     if: "startsWith(github.ref, 'refs/tags/lib-')"
     continue-on-error: true
-    steps:
-      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ github.ref_name }}"
-          name: "pyroscope-${{ github.ref_name }}"
-          draft: true
-          prerelease: false
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      release_name: "pyroscope-${{ github.ref_name }}"
+      draft: true
+      prerelease: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   clibuilder-release:
     name: clibuilder-release
     runs-on: ubuntu-latest
@@ -58,21 +58,18 @@ jobs:
 
   cli-release:
     name: pyroscope-cli
-    runs-on: ubuntu-latest
     permissions:
       contents: write
     if: "startsWith(github.ref, 'refs/tags/cli-')"
-    outputs:
-      upload_url: ${{ steps.auto-release.outputs.upload_url }}
-    steps:
-      - id: auto-release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ github.ref_name }}"
-          name: "pyroscope-${{ github.ref_name }}"
-          draft: true
-          prerelease: false
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      release_name: "pyroscope-${{ github.ref_name }}"
+      draft: true
+      prerelease: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   cli-artifacts:
     name: pyroscope-cli - build aritifacts
     needs: cli-release
@@ -101,51 +98,67 @@ jobs:
           asset_path: "./pyroscope-cli"
           asset_name: "pyroscope-cli"
           asset_content_type: application/octet-stream
+
   pprofrs-release:
     name: pyroscope-pprofrs
-    runs-on: ubuntu-latest
     permissions:
       contents: write
     if: "startsWith(github.ref, 'refs/tags/pprofrs-')"
     continue-on-error: true
-    steps:
-      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ github.ref_name }}"
-          name: "Backend: ${{ github.ref_name }}"
-          draft: true
-          prerelease: false
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      release_name: "Backend: ${{ github.ref_name }}"
+      draft: true
+      prerelease: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   rbspy-release:
     name: pyroscope-rbspy
-    runs-on: ubuntu-latest
     permissions:
       contents: write
     if: "startsWith(github.ref, 'refs/tags/rbspy-')"
     continue-on-error: true
-    steps:
-      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ github.ref_name }}"
-          name: "Backend: ${{ github.ref_name }}"
-          draft: true
-          prerelease: false
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      release_name: "Backend: ${{ github.ref_name }}"
+      draft: true
+      prerelease: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   pyspy-release:
     name: pyroscope-pyspy
-    runs-on: ubuntu-latest
     permissions:
       contents: write
     if: "startsWith(github.ref, 'refs/tags/pyspy-')"
     continue-on-error: true
-    steps:
-      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ github.ref_name }}"
-          name: "Backend: ${{ github.ref_name }}"
-          draft: true
-          prerelease: false
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      release_name: "Backend: ${{ github.ref_name }}"
+      draft: true
+      prerelease: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  python-release:
+    name: Python Package
+    permissions:
+      contents: write
+    if: "startsWith(github.ref, 'refs/tags/python-')"
+    continue-on-error: true
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      release_name: "Python Package: ${{ github.ref_name }}"
+      draft: true
+      prerelease: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   python-release-linux:
     needs: [ 'python-release' ]
     name: Release python linux amd64
@@ -278,24 +291,22 @@ jobs:
         with:
           upload_url: ${{ needs.python-release.outputs.upload_url }}
           asset_path: "pyroscope_ffi/python/dist/pyroscope-io-*.tar.gz"
-  python-release:
-    name: Python Package
-    runs-on: ubuntu-latest
+
+  ruby-release:
+    name: Ruby Gem
     permissions:
       contents: write
-    if: "startsWith(github.ref, 'refs/tags/python-')"
+    if: "startsWith(github.ref, 'refs/tags/ruby-')"
     continue-on-error: true
-    outputs:
-      upload_url: ${{ steps.auto-release.outputs.upload_url }}
-    steps:
-      - id: auto-release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ github.ref_name }}"
-          name: "Python Package: ${{ github.ref_name }}"
-          draft: true
-          prerelease: false
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      release_name: "Ruby Gem: ${{ github.ref_name }}"
+      draft: true
+      prerelease: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   ruby-release-linux:
     needs: [ 'ruby-release' ]
     name: Release Linux gem amd64
@@ -428,22 +439,3 @@ jobs:
         with:
           upload_url: ${{ needs.ruby-release.outputs.upload_url }}
           asset_path: "pyroscope_ffi/ruby/pkg/*.gem"
-
-  ruby-release:
-    name: Ruby Gem
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    if: "startsWith(github.ref, 'refs/tags/ruby-')"
-    continue-on-error: true
-    outputs:
-      upload_url: ${{ steps.auto-release.outputs.upload_url }}
-    steps:
-      - id: auto-release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ github.ref_name }}"
-          name: "Ruby Gem: ${{ github.ref_name }}"
-          draft: true
-          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,27 +2,36 @@ name: Pre-Release
 
 on: [ push ]
 
+permissions:
+  contents: read
+
 jobs:
   lib-release:
     name: pyroscope-main
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: "startsWith(github.ref, 'refs/tags/lib-')"
     continue-on-error: true
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.ref_name }}"
-          title: "pyroscope-${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          name: "pyroscope-${{ github.ref_name }}"
           draft: true
           prerelease: false
   clibuilder-release:
     name: clibuilder-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: "startsWith(github.ref, 'refs/tags/clibuilder-')"
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/login-action@v2
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         name: Login to Docker Hub
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -32,10 +41,14 @@ jobs:
   manylinux-release:
     name: manylinux-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: "startsWith(github.ref, 'refs/tags/manylinux-')"
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/login-action@v2
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         name: Login to Docker Hub
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -46,27 +59,32 @@ jobs:
   cli-release:
     name: pyroscope-cli
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: "startsWith(github.ref, 'refs/tags/cli-')"
     outputs:
       upload_url: ${{ steps.auto-release.outputs.upload_url }}
     steps:
       - id: auto-release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.ref_name }}"
-          title: "pyroscope-${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          name: "pyroscope-${{ github.ref_name }}"
           draft: true
           prerelease: false
   cli-artifacts:
     name: pyroscope-cli - build aritifacts
     needs: cli-release
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
+          persist-credentials: false
           submodules: recursive
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         name: Login to Docker Hub
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -75,7 +93,7 @@ jobs:
       - run: DOCKER_EXTRA="--output=." make cli/docker-image
 
       - name: Upload release archive
-        uses: actions/upload-release-asset@v1.0.1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -86,57 +104,67 @@ jobs:
   pprofrs-release:
     name: pyroscope-pprofrs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: "startsWith(github.ref, 'refs/tags/pprofrs-')"
     continue-on-error: true
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.ref_name }}"
-          title: "Backend: ${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          name: "Backend: ${{ github.ref_name }}"
           draft: true
           prerelease: false
   rbspy-release:
     name: pyroscope-rbspy
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: "startsWith(github.ref, 'refs/tags/rbspy-')"
     continue-on-error: true
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.ref_name }}"
-          title: "Backend: ${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          name: "Backend: ${{ github.ref_name }}"
           draft: true
           prerelease: false
   pyspy-release:
     name: pyroscope-pyspy
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: "startsWith(github.ref, 'refs/tags/pyspy-')"
     continue-on-error: true
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.ref_name }}"
-          title: "Backend: ${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          name: "Backend: ${{ github.ref_name }}"
           draft: true
           prerelease: false
   python-release-linux:
     needs: [ 'python-release' ]
     name: Release python linux amd64
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v3
+      - uses: AutoModality/action-clean@492b2d2e2e77247bfd0b17eaa89a371b2f3430ee # v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - run: make wheel/linux/amd64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -146,18 +174,22 @@ jobs:
     needs: [ 'python-release' ]
     name: Release python linux arm64
     runs-on: [self-hosted, Linux, ARM64]
+    permissions:
+      contents: write
 
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v3
+      - uses: AutoModality/action-clean@492b2d2e2e77247bfd0b17eaa89a371b2f3430ee # v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - run: make wheel/linux/arm64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -180,30 +212,32 @@ jobs:
 
     name: macOS - ${{ matrix.py-platform }}
     runs-on: macos-${{ matrix.macos-version }}
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.76.0
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
+          targets: ${{ matrix.target }}
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: 3.11
 
       - run: make pyroscope_ffi/clean wheel/mac/${{ matrix.mk-arch }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -213,12 +247,16 @@ jobs:
     needs: [ 'python-release' ]
     name: sdist
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v3
+      - uses: AutoModality/action-clean@492b2d2e2e77247bfd0b17eaa89a371b2f3430ee # v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: 3.9
       - name: Upgrade pip
@@ -228,13 +266,13 @@ jobs:
         run: python setup.py sdist
         working-directory: pyroscope_ffi/python
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -243,34 +281,40 @@ jobs:
   python-release:
     name: Python Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: "startsWith(github.ref, 'refs/tags/python-')"
     continue-on-error: true
     outputs:
       upload_url: ${{ steps.auto-release.outputs.upload_url }}
     steps:
       - id: auto-release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.ref_name }}"
-          title: "Python Package: ${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          name: "Python Package: ${{ github.ref_name }}"
           draft: true
           prerelease: false
   ruby-release-linux:
     needs: [ 'ruby-release' ]
     name: Release Linux gem amd64
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v3
+      - uses: AutoModality/action-clean@492b2d2e2e77247bfd0b17eaa89a371b2f3430ee # v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - run: make gem/linux/amd64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -281,17 +325,21 @@ jobs:
     needs: [ 'ruby-release' ]
     name: Release Linux gem arm64
     runs-on: [ self-hosted, Linux, ARM64 ]
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - run: make gem/linux/arm64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -313,28 +361,30 @@ jobs:
 
     name: macOS - ${{ matrix.target }}
     runs-on: macos-${{ matrix.macos-version }}
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '3.1'
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: 1.76.0
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
+          targets: ${{ matrix.target }}
 
       - run: make pyroscope_ffi/clean gem/mac/${{ matrix.mk-arch }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -345,12 +395,16 @@ jobs:
     needs: [ 'ruby-release' ]
     name: source
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v3
+      - uses: AutoModality/action-clean@492b2d2e2e77247bfd0b17eaa89a371b2f3430ee # v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '3.1'
 
@@ -362,13 +416,13 @@ jobs:
         run: rake source:gem
         working-directory: pyroscope_ffi/ruby
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -378,16 +432,18 @@ jobs:
   ruby-release:
     name: Ruby Gem
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: "startsWith(github.ref, 'refs/tags/ruby-')"
     continue-on-error: true
     outputs:
       upload_url: ${{ steps.auto-release.outputs.upload_url }}
     steps:
       - id: auto-release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.ref_name }}"
-          title: "Ruby Gem: ${{ github.ref_name }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{ github.ref_name }}"
+          name: "Ruby Gem: ${{ github.ref_name }}"
           draft: true
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,9 +171,9 @@ jobs:
         with:
           persist-credentials: false
       - run: make wheel/linux/amd64
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: python-linux-amd64-${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
@@ -196,9 +196,9 @@ jobs:
         with:
           persist-credentials: false
       - run: make wheel/linux/arm64
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: python-linux-arm64-${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
@@ -244,9 +244,9 @@ jobs:
 
       - run: make pyroscope_ffi/clean wheel/mac/${{ matrix.mk-arch }}
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: python-macos-${{ matrix.mk-arch }}-${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
@@ -279,9 +279,9 @@ jobs:
         run: python setup.py sdist
         working-directory: pyroscope_ffi/python
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: python-sdist-${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
@@ -319,9 +319,9 @@ jobs:
         with:
           persist-credentials: false
       - run: make gem/linux/amd64
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: ruby-linux-amd64-${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
@@ -344,9 +344,9 @@ jobs:
         with:
           persist-credentials: false
       - run: make gem/linux/arm64
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: ruby-linux-arm64-${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
@@ -389,9 +389,9 @@ jobs:
 
       - run: make pyroscope_ffi/clean gem/mac/${{ matrix.mk-arch }}
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: ruby-macos-${{ matrix.mk-arch }}-${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
@@ -427,9 +427,9 @@ jobs:
         run: rake source:gem
         working-directory: pyroscope_ffi/ruby
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ github.sha }}
+          name: ruby-source-${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact


### PR DESCRIPTION
## Summary

Security hardening of GitHub Actions workflows based on a zizmor audit (164 findings across 4 workflow files).

- Pin all action refs to commit SHAs to prevent supply-chain attacks via mutable tags
- Replace 3 archived actions with maintained equivalents
- Scope `permissions:` to least privilege per job (default `contents: read`, `contents: write` only for release jobs)
- Add `persist-credentials: false` to all `actions/checkout` steps
- Fix template-injection in `publish-ruby` job by routing matrix value through an env var

## Changes

| Rule | Count | Fix applied |
|---|---|---|
| `unpinned-uses` | 87 | Pinned all mutable action refs to commit SHAs; verified tag immutability via GitHub rulesets API before pinning — no repos had active deletion/non-fast-forward rules |
| `excessive-permissions` | 37 | Added `permissions: contents: read` at workflow level; scoped `contents: write` to jobs that create GitHub releases |
| `artipacked` | 23 | Added `persist-credentials: false` to all `actions/checkout` steps |
| `archived-uses` | 16 | Replaced `actions-rs/toolchain` → `dtolnay/rust-toolchain`, `marvinpinto/action-automatic-releases` → `ncipollo/release-action`, `actions/upload-release-asset` → `korniltsev/actions-upload-release-asset` (already in use in the same file) |
| `template-injection` | 1 | `publish-ruby` job: moved `${{ matrix.file }}` out of `run:` block into `env: GEM_FILE` and referenced `"$GEM_FILE"` in shell |

## Tag immutability verification

All 13 action repos were checked for active tag-protection rulesets (`DELETE` and `non_fast_forward` rules) via `GET /repos/{owner}/{repo}/rulesets`. **All returned `false`** (no active immutability rulesets), so every mutable tag was replaced with its commit SHA.

| Action | Tag | SHA pinned to |
|---|---|---|
| `actions/checkout` | `v3` | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/upload-artifact` | `v2` | `82c141cc518b40d92cc801eee768e7aafc9c2fa2` |
| `actions/download-artifact` | `v2` | `cbed621e49e4c01b044d60f6c80ea4ed6328b281` |
| `actions/setup-python` | `v4` | `7f4fc3e22c37d6ff65e88745f38bd3157c663f7c` |
| `docker/login-action` | `v2` | `465a07811f14bebb1938fbed4728c6a1ff8901fc` |
| `ruby/setup-ruby` | `v1.99.0` | `e5517072e87f198d9533967ae13d97c11b604005` |
| `AutoModality/action-clean` | `v1` | `492b2d2e2e77247bfd0b17eaa89a371b2f3430ee` |
| `korniltsev/actions-upload-release-asset` | `v1` | `a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e` |
| `robinraju/release-downloader` | `v1.4` | `ed86e52bc497d1185844fc28454c5999aaed2fa5` |
| `pypa/gh-action-pypi-publish` | `release/v1` (branch) | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` |
| `dtolnay/rust-toolchain` (replaces `actions-rs/toolchain`) | `master` | `3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9` |
| `ncipollo/release-action` (replaces `marvinpinto/action-automatic-releases`) | `v1.21.0` | `339a81892b84b4eeb0f6e744e4574d79d0d9b8dd` |

## Test plan
- [ ] All 4 workflow YAML files parse without errors (`python3 -c "import yaml; yaml.safe_load(...)"` — verified locally)
- [ ] CI passes on this branch
- [ ] No remaining zizmor findings at error severity